### PR TITLE
CursorHold時にハイライトを有効にしたい

### DIFF
--- a/doc/brightest.jax
+++ b/doc/brightest.jax
@@ -144,6 +144,14 @@ b:brightest_ignore_word_pattern		*b:brightest_ignore_word_pattern*
 	g:brightest#ignore_word_pattern のバッファローカル版です。
 	g:brightest#ignore_word_pattern よりも優先して使用されます。
 
+g:brightest_on_cursor_hold		*g:brightest_on_cursor_hold*
+	もし値が0以外である場合、
+	カーソルが動いた後(|CursorMoved|)にハイライトするのではなく、
+	カーソルが動いて'updatetime'ミリ秒経った後(|CursorHold|)に、
+	ハイライトします。
+Default: >
+	let g:brightest_on_cursor_hold = 0
+<
 
 ==============================================================================
 ハイライトグループ				*brightest-highlight_group*

--- a/plugin/brightest.vim
+++ b/plugin/brightest.vim
@@ -9,6 +9,7 @@ set cpo&vim
 
 
 let g:brightest_enable = get(g:, "brightest_enable", 1)
+let g:brightest_on_cursor_hold = get(g:, "brightest_on_cursor_hold", 0)
 
 
 function! s:init_hl()
@@ -29,7 +30,9 @@ command! -bar BrightestDisable let g:brightest_enable = 0 | BrightestClear
 
 augroup brightest
 	autocmd!
-	autocmd CursorMoved * call brightest#highlighting()
+	execute 'autocmd'
+\		(g:brightest_on_cursor_hold ? 'CursorHold' : 'CursorMoved')
+\		'* call brightest#highlighting()'
 	autocmd BufLeave,WinLeave,InsertEnter * call brightest#hl_clear()
 	autocmd ColorScheme * call s:init_hl()
 augroup END


### PR DESCRIPTION
via #2 

現状、カーソル下の単語を即座にハイライトしていますが、
これをCursorHold時にハイライトを有効にすれば、
重くならないだろうと考えたのですが、どうでしょうか。

(ちなみにEclipseでも、何msecか経った後にハイライトしてます)