### PR TITLE
finish if v:version < 702

### DIFF
--- a/plugin/brightest.vim
+++ b/plugin/brightest.vim
@@ -1,5 +1,5 @@
 scriptencoding utf-8
-if exists('g:loaded_brightest')
+if exists('g:loaded_brightest') || v:version < 702
   finish
 endif
 let g:loaded_brightest = 1


### PR DESCRIPTION
Vim 7.1で確認したところエラーが出て動かないのでfinishにしました。(多分古いVimではメンテできないと思いますので、< 703にしようかなとも思いましたが、 https://github.com/osyo-manga/vim-brightest/blob/master/autoload/vital/_brightest.vim#L4 を見て7.2でも動くようにしているのかなぁと思いました。)